### PR TITLE
Handle properties where there is no value and default to empty string

### DIFF
--- a/BeyondTrustConnector.Tests/ParserTests.cs
+++ b/BeyondTrustConnector.Tests/ParserTests.cs
@@ -18,7 +18,8 @@ Dec 10 07:04:11 tenant BG[12482]: 1427:01:01:event=login;site=tenant.beyondtrust
         var parser = new BeyondTrustLogParser(log);
         var events = parser.Parse();
         Assert.Equal(2, events.Count);
-        Assert.Equal(97, events.First().AdditionalData.Count);
+        Assert.Equal(101, events.First().AdditionalData.Count);
+        Assert.Equal("", events.First().AdditionalData["old_account:comments"]);
     }
 
     [Fact]

--- a/BeyondTrustConnector/Parser/PayloadParser.cs
+++ b/BeyondTrustConnector/Parser/PayloadParser.cs
@@ -27,6 +27,11 @@
 
         private string ParseValue()
         {
+            if(Current == ';')
+            {
+                _position++;
+                return "";
+            }
             var start = _position;
             do
             {


### PR DESCRIPTION
Handle properties where there is no value and default to empty string

#### PR Classification
Bug fix to handle empty values in the parser and update test expectations.

#### PR Summary
Updated the parser to correctly handle empty values and adjusted test cases accordingly.
- `ParserTests.cs`: Updated expected `AdditionalData` count from 97 to 101 and added assertion for `old_account:comments` field to be an empty string.
- `PayloadParser.cs`: Added condition to handle semicolon (`;`) as an indicator of an empty value, returning an empty string.
