### PR TITLE
Improve null handling in AccessSessionUpdater.cs

### DIFF
--- a/BeyondTrustConnector/AccessSessionUpdater.cs
+++ b/BeyondTrustConnector/AccessSessionUpdater.cs
@@ -78,11 +78,11 @@ namespace BeyondTrustConnector
                 var userDetails = new Dictionary<string, object>();
                 if (userElement is not null)
                 {
-                    userDetails.Add("Username", userElement.Element(XName.Get("username", ns))!.Value);
-                    userDetails.Add("PublicIP", userElement.Element(XName.Get("public_ip", ns))!.Value);
-                    userDetails.Add("PrivateIP", userElement.Element(XName.Get("private_ip", ns))!.Value);
+                    userDetails.Add("Username", userElement.Element(XName.Get("username", ns))?.Value ?? "Unknown");
+                    userDetails.Add("PublicIP", userElement.Element(XName.Get("public_ip", ns))?.Value ?? "Unknown");
+                    userDetails.Add("PrivateIP", userElement.Element(XName.Get("private_ip", ns))?.Value ?? "Unknown");
                     userDetails.Add("Hostname", userElement.Element(XName.Get("hostname", ns))?.Value ?? "Unknown");
-                    userDetails.Add("OS", userElement.Element(XName.Get("os", ns))!.Value);
+                    userDetails.Add("OS", userElement.Element(XName.Get("os", ns))?.Value ?? "Unknown");
                     var sessionOwnerData = userElement.Element(XName.Get("session_owner", ns))?.Value;
                     if (!string.IsNullOrEmpty(sessionOwnerData))
                     {


### PR DESCRIPTION
Improve null handling in AccessSessionUpdater.cs

Replaced null-forgiving operator with null-coalescing operator
in the BeyondTrustConnector namespace. This change ensures
that a default value of "Unknown" is assigned to user details
if XML elements are missing or null, enhancing code robustness.

#### PR Classification
Code cleanup to improve robustness by handling potential null values.

#### PR Summary
Replaced null-forgiving operator with null-coalescing operator to ensure default values are assigned for missing or null XML elements.
- `AccessSessionUpdater.cs`: Updated handling of "username", "public_ip", "private_ip", and "os" elements to use "Unknown" as default if null.
