### PR TITLE
Add filetransfer details

### DIFF
--- a/BeyondTrustConnector/AccessSessionUpdater.cs
+++ b/BeyondTrustConnector/AccessSessionUpdater.cs
@@ -45,7 +45,6 @@ public class AccessSessionUpdater(BeyondTrustService beyondTrustService, Ingesti
             var jumpItemId = jumpItem!.Attribute("gsnumber")!.Value;
             var jumpGroup = session.Element(XName.Get("jump_group", ns))!.Value;
             var sessionType = session.Element(XName.Get("session_type", ns))!.Value;
-
             var sessionData = new BeyondTrustAccessSession
             {
                 StartTime = startTime.UtcDateTime,
@@ -57,6 +56,21 @@ public class AccessSessionUpdater(BeyondTrustService beyondTrustService, Ingesti
                 JumpGroup = jumpGroup,
                 SessionType = sessionType
             };
+
+            if (int.TryParse(session.Element(XName.Get("file_transfer_count", ns))?.Value, out var fileTransferCount))
+            {
+                sessionData.FileTransferCount = fileTransferCount;
+            }
+
+            if (int.TryParse(session.Element(XName.Get("file_move_count", ns))?.Value, out var fileMoveCount))
+            {
+                sessionData.FileMoveCount = fileMoveCount;
+            }
+
+            if (int.TryParse(session.Element(XName.Get("file_move_count", ns))?.Value, out var fileDeleteCount))
+            {
+                sessionData.FileDeleteCount = fileDeleteCount;
+            }
 
             try
             {

--- a/BeyondTrustConnector/Model/BeyondTrustAccessSession.cs
+++ b/BeyondTrustConnector/Model/BeyondTrustAccessSession.cs
@@ -11,4 +11,7 @@ public class BeyondTrustAccessSession
     public required string JumpItemAddress { get; set; }
     public int JumpItemId { get; set; }
     public IEnumerable<Dictionary<string, object>> UserDetails { get; set; } = [];
+    public int? FileTransferCount { get; set; }
+    public int? FileMoveCount { get; set; }
+    public int? FileDeleteCount { get; set; }
 }

--- a/modules/datacollection.bicep
+++ b/modules/datacollection.bicep
@@ -144,6 +144,18 @@ resource Custom_Table_BeyondTrustAccessSession_CL 'Microsoft.OperationalInsights
           name: 'UserDetails'
           type: 'dynamic'
         }
+        {
+          name: 'FileTransferCount'
+          type: 'int'
+        }
+        {
+          name: 'FileMoveCount'
+          type: 'int'
+        }
+        {
+          name: 'FileDeleteCount'
+          type: 'int'
+        }
       ]
     }
     retentionInDays: 30
@@ -248,6 +260,18 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' 
           }
           {
             name: 'UserId'
+            type: 'int'
+          }
+          {
+            name: 'FileTransferCount'
+            type: 'int'
+          }
+          {
+            name: 'FileMoveCount'
+            type: 'int'
+          }
+          {
+            name: 'FileDeleteCount'
             type: 'int'
           }
         ]


### PR DESCRIPTION
This pull request includes several changes to the `BeyondTrustConnector` project, focusing on improving session data handling and updating the data collection schema. The most important changes include adding new properties to the `BeyondTrustAccessSession` model, modifying the session data creation process, and updating the data collection rules.

### Session Data Handling Improvements:

* Added new properties `FileTransferCount`, `FileMoveCount`, and `FileDeleteCount` to the `BeyondTrustAccessSession` model. (`BeyondTrustConnector/Model/BeyondTrustAccessSession.cs`)
* Introduced a new method `CreateSessionData` to handle session data creation, including parsing new properties and handling errors. (`BeyondTrustConnector/AccessSessionUpdater.cs`) [[1]](diffhunk://#diff-f597f9bd940d99cf575a485d092dc091e0585e32f3d11dc84766e50cc9216b0bR23-R52) [[2]](diffhunk://#diff-f597f9bd940d99cf575a485d092dc091e0585e32f3d11dc84766e50cc9216b0bL61-R123)
* Updated the `CheckIfSessionsAlreadyExists` method to process session IDs in batches, improving performance and avoiding potential issues with large queries. (`BeyondTrustConnector/AccessSessionUpdater.cs`)

### Data Collection Schema Updates:

* Added new fields `FileTransferCount`, `FileMoveCount`, and `FileDeleteCount` to the custom table schema for `BeyondTrustAccessSession_CL`. (`modules/datacollection.bicep`)
* Updated the data collection rule to include the new fields, ensuring they are properly ingested and stored. (`modules/datacollection.bicep`)

### Code Cleanup:

* Removed unused `using` directives from `BeyondTrustConnector/AccessSessionUpdater.cs`.