### PR TITLE
Add license usage reporting

### DIFF
--- a/BeyondTrustConnector/LicenseUsageUpdater.cs
+++ b/BeyondTrustConnector/LicenseUsageUpdater.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO.Compression;
+using BeyondTrustConnector.Model.Dto;
+using BeyondTrustConnector.Service;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace BeyondTrustConnector
+{
+    public class LicenseUsageUpdater(BeyondTrustService beyondTrustService, IngestionService ingestionService, ILogger<LicenseUsageUpdater> logger)
+    {
+        [Function(nameof(LicenseUsageUpdater))]
+        public async Task Run([TimerTrigger("0 0 8 * * *", RunOnStartup = true)] TimerInfo myTimer)
+        {
+            var reportArchive = await beyondTrustService.GetEndpointLicenseUsageReportAsync();
+            ZipArchive archive = new(new MemoryStream(reportArchive));
+            var jumpItemReport = archive.GetEntry("jump_items.csv");
+            if (jumpItemReport is null)
+            {
+                logger.LogError("Jump Items report not found in archive");
+                throw new Exception("Jump Items report not found in archive");
+            }
+            
+            using var jumpItemStream = jumpItemReport.Open();
+            using var jumpItemReader = new StreamReader(jumpItemStream);
+            var csvLine = await jumpItemReader.ReadLineAsync();
+
+            var licenseEntries = new List<BeyondTrustLicenseEntryDto>();
+            while ((csvLine = await jumpItemReader.ReadLineAsync()) != null){
+                var fields = csvLine.Split(',');
+                var licenseEntry = new BeyondTrustLicenseEntryDto
+                {
+                    JumpItemName = fields[0].Trim('\"'),
+                    HostnameOrIp = fields[1].Trim('\"'),
+                    Jumpoint = fields[2].Trim('\"'),
+                    RemoteApplicationName = fields[3].Trim('\"'),
+                    License = fields[4].Trim('\"') == "yes",
+                    JumpMethod = fields[5].Trim('\"'),
+                    JumpGroup = fields[6].Trim('\"'),
+                };
+                licenseEntries.Add(licenseEntry);
+            }
+            if(licenseEntries.Count == 0)
+            {
+                logger.LogWarning("No license entries found in report");
+                return;
+            }
+
+            await ingestionService.IngestLicenseUsage(licenseEntries);
+        }
+    }
+}

--- a/BeyondTrustConnector/LicenseUsageUpdater.cs
+++ b/BeyondTrustConnector/LicenseUsageUpdater.cs
@@ -10,7 +10,7 @@ namespace BeyondTrustConnector
     public class LicenseUsageUpdater(BeyondTrustService beyondTrustService, IngestionService ingestionService, ILogger<LicenseUsageUpdater> logger)
     {
         [Function(nameof(LicenseUsageUpdater))]
-        public async Task Run([TimerTrigger("0 0 8 * * *", RunOnStartup = true)] TimerInfo myTimer)
+        public async Task Run([TimerTrigger("0 0 8 * * *", RunOnStartup = false)] TimerInfo myTimer)
         {
             var reportArchive = await beyondTrustService.GetEndpointLicenseUsageReportAsync();
             ZipArchive archive = new(new MemoryStream(reportArchive));

--- a/BeyondTrustConnector/Model/Dto/BeyondTrustLicenseEntryDto.cs
+++ b/BeyondTrustConnector/Model/Dto/BeyondTrustLicenseEntryDto.cs
@@ -1,0 +1,12 @@
+﻿namespace BeyondTrustConnector.Model.Dto;
+
+internal class BeyondTrustLicenseEntryDto
+{
+    public required string JumpItemName { get; set; }
+    public required string HostnameOrIp { get; set; }
+    public required string JumpMethod { get; set; }
+    public required string JumpGroup { get; set; }
+    public bool License { get; set; }
+    public required string Jumpoint { get; set; }
+    public string? RemoteApplicationName { get; set; }
+}

--- a/BeyondTrustConnector/Service/IngestionService.cs
+++ b/BeyondTrustConnector/Service/IngestionService.cs
@@ -19,6 +19,11 @@ public class IngestionService(ILogger<IngestionService> logger)
         await Ingest("BeyondTrustAccessSession_CL", sessions);
     }
 
+    internal async Task IngestLicenseUsage(List<BeyondTrustLicenseEntryDto> licenseEntries)
+    {
+        await Ingest("BeyondTrustLicenseUsage_CL", licenseEntries);
+    }
+
     internal async Task IngestVaultActivity(List<BeyondTrustVaultActivityDto> vaultActivities)
     {
         await Ingest("BeyondTrustVaultActivity_CL", vaultActivities);

--- a/modules/datacollection.bicep
+++ b/modules/datacollection.bicep
@@ -21,12 +21,12 @@ resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2023
 
 resource Custom_Table_BeyondTrustLicenseUsage_CL 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' = {
   parent: law
-  name: 'BeyondTrustVaultLicenseUsage_CL'
+  name: 'BeyondTrustLicenseUsage_CL'
   properties: {
     totalRetentionInDays: 30
     plan: 'Analytics'
     schema: {
-      name: 'BeyondTrustVaultLicenseUsage_CL'
+      name: 'BeyondTrustLicenseUsage_CL'
       columns: [
           {
             name: 'TimeGenerated'

--- a/modules/datacollection.bicep
+++ b/modules/datacollection.bicep
@@ -19,7 +19,48 @@ resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2023
   }
 }
 
-
+resource Custom_Table_BeyondTrustLicenseUsage_CL 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' = {
+  parent: law
+  name: 'BeyondTrustVaultLicenseUsage_CL'
+  properties: {
+    totalRetentionInDays: 30
+    plan: 'Analytics'
+    schema: {
+      name: 'BeyondTrustVaultLicenseUsage_CL'
+      columns: [
+          {
+            name: 'TimeGenerated'
+            type: 'datetime'
+          }
+          {
+            name: 'Name'
+            type: 'string'
+          }
+          {
+            name: 'HostnameOrIp'
+            type: 'string'
+          }
+          {
+            name: 'Jumpoint'
+            type: 'string'
+          }
+          {
+            name: 'License'
+            type: 'boolean'
+          }
+          {
+            name: 'JumpMethod'
+            type: 'string'
+          }
+          {
+            name: 'JumpGroup'
+            type: 'string'
+          }
+      ]
+    }
+    retentionInDays: 30
+  }
+}
 
 resource Custom_Table_BeyondTrustVaultActivity_CL 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' = {
   parent: law
@@ -184,6 +225,38 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' 
   properties: {
     dataCollectionEndpointId: dataCollectionEndpoint.id
     streamDeclarations: {
+        'Custom-BeyondTrustLicenseUsage_CL': {
+        columns: [
+          {
+            name: 'TimeGenerated'
+            type: 'datetime'
+          }
+          {
+            name: 'Name'
+            type: 'string'
+          }
+          {
+            name: 'HostnameOrIp'
+            type: 'string'
+          }
+          {
+            name: 'Jumpoint'
+            type: 'string'
+          }
+          {
+            name: 'License'
+            type: 'boolean'
+          }
+          {
+            name: 'JumpMethod'
+            type: 'string'
+          }
+          {
+            name: 'JumpGroup'
+            type: 'string'
+          }
+        ]
+      }
       'Custom-BeyondTrustEvents_CL': {
         columns: [
           {
@@ -319,6 +392,16 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' 
       ]
     }
     dataFlows: [
+        {
+        streams: [
+          'Custom-BeyondTrustLicenseUsage_CL'
+        ]
+        destinations: [
+          'beyondTrustWorkspace'
+        ]
+        transformKql: 'source\n| extend TimeGenerated=now()\n'
+        outputStream: 'Custom-BeyondTrustLicenseUsage_CL'
+      }
       {
         streams: [
           'Custom-BeyondTrustEvents_CL'


### PR DESCRIPTION
#### PR Classification
New feature to fetch and process license usage reports.

#### PR Summary
Introduced functionality to fetch and process BeyondTrust license usage reports, including necessary data ingestion and storage updates.
- Added `LicenseUsageUpdater` class in `BeyondTrustConnector` namespace with a `Run` method.
- Created `BeyondTrustLicenseEntryDto` class in `BeyondTrustConnector.Model.Dto`.
- Updated `BeyondTrustService` with a new method `GetEndpointLicenseUsageReportAsync` and changed method access modifiers to `internal`.
- Added `IngestLicenseUsage` method in `IngestionService`.
- Updated `datacollection.bicep` to define a new custom table and data flow for `BeyondTrustLicenseUsage_CL`.
