### PR TITLE
Rename field in data collection rule and update KQL query

### DIFF
--- a/modules/datacollection.bicep
+++ b/modules/datacollection.bicep
@@ -232,7 +232,7 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' 
             type: 'datetime'
           }
           {
-            name: 'Name'
+            name: 'JumpItemName'
             type: 'string'
           }
           {
@@ -399,7 +399,7 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' 
         destinations: [
           'beyondTrustWorkspace'
         ]
-        transformKql: 'source\n| extend TimeGenerated=now()\n'
+        transformKql: 'source\n| extend TimeGenerated=now()\n|project-rename Name=JumpItemName\n'
         outputStream: 'Custom-BeyondTrustLicenseUsage_CL'
       }
       {


### PR DESCRIPTION
The name of a field in the data collection rule has been changed from 'Name' to 'JumpItemName'. The KQL transformation query has been updated to rename the 'JumpItemName' field back to 'Name' using the `project-rename` operator.