### PR TITLE
Update BeyondTrust config to use URL instead of tenant name

### DIFF
--- a/BeyondTrustConnector/Program.cs
+++ b/BeyondTrustConnector/Program.cs
@@ -12,9 +12,9 @@ builder.Services.AddTransient<QueryService>();
 builder.Services.AddHttpClient(nameof(BeyondTrustConnector), (provider,client)=>
 {
     var beyondTrustCredentialClient = provider.GetRequiredService<BeyondTrustCredentialClient>();
-    var beyondTrustTenantName = Environment.GetEnvironmentVariable("BEYONDTRUST_TENANT") ?? throw new Exception("BEYONDTRUST_TENANT environment variable is not set");
-    client.BaseAddress = new Uri($"https://{beyondTrustTenantName}.beyondtrustcloud.com");
-    var token = beyondTrustCredentialClient.GetAccessToken(beyondTrustTenantName).Result;
+    var beyondTrustUrl = Environment.GetEnvironmentVariable("BEYONDTRUST_URL") ?? throw new Exception("BEYONDTRUST_URL environment variable is not set");
+    client.BaseAddress = new Uri(beyondTrustUrl);
+    var token = beyondTrustCredentialClient.GetAccessToken(beyondTrustUrl).Result;
     client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
 });
 builder.Services.AddTransient<IngestionService>();

--- a/BeyondTrustConnector/Service/BeyondTrustCredentialClient.cs
+++ b/BeyondTrustConnector/Service/BeyondTrustCredentialClient.cs
@@ -8,7 +8,7 @@ namespace BeyondTrustConnector.Service;
 
 internal class BeyondTrustCredentialClient(IHttpClientFactory httpClientFactory, ILogger<BeyondTrustCredentialClient> logger)
 {
-    public async Task<string> GetAccessToken(string beyondTrustTenantName)
+    public async Task<string> GetAccessToken(string beyondTrustUrl)
     {
         var secretName = Environment.GetEnvironmentVariable("KEYVAULT_SECRET") ?? throw new Exception("KEYVAULT_SECRET environment variable is not set");
         var secret = await SecretReader.GetSecretAsync(secretName);
@@ -16,7 +16,7 @@ internal class BeyondTrustCredentialClient(IHttpClientFactory httpClientFactory,
         var client = httpClientFactory.CreateClient();
         var basicAuth = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{credential.ClientId}:{credential.ClientSecret}"));
         client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", basicAuth);
-        var response = await client.PostAsync($"https://{beyondTrustTenantName}.beyondtrustcloud.com/oauth2/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        var response = await client.PostAsync($"{beyondTrustUrl}/oauth2/token", new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 { "grant_type", "client_credentials" }
             }));

--- a/main.bicep
+++ b/main.bicep
@@ -11,7 +11,7 @@ type functionAppConfig = {
   container: string
 }
 
-param beyondTrustTenant string
+param beyondTrustApplianceUrl string
 param datacollection dataCollectionConfig
 param functionConfig functionAppConfig
 
@@ -44,7 +44,7 @@ module functionappModule './modules/functionapp.bicep' = {
       workspaceName: datacollectionModule.outputs.workspaceId
       endpointImmutableId: datacollectionModule.outputs.dcrImmutableId
       endpointUri: datacollectionModule.outputs.logsIngestionEndpoint
-      beyondTrustTenant: beyondTrustTenant
+      beyondTrustApplianceUrl: beyondTrustApplianceUrl
     }
   }
 }

--- a/main.bicepparam
+++ b/main.bicepparam
@@ -1,7 +1,7 @@
 using './main.bicep'
 
 // Specify your BeyondTrust tenant name
-param beyondTrustTenant = 'mytenant'
+param beyondTrustApplianceUrl = 'https://mytenant.beyondtrustcloud.com'
 
 // Data collection configuration
 param datacollection = {

--- a/modules/functionapp.bicep
+++ b/modules/functionapp.bicep
@@ -2,7 +2,7 @@ type dataCollectionConfig = {
   endpointImmutableId: string
   endpointUri: string
   workspaceName: string
-  beyondTrustTenant: string
+  beyondTrustApplianceUrl: string
 }
 
 param dataCollection dataCollectionConfig
@@ -98,8 +98,8 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           value: dataCollection.endpointUri
         }
         {
-          name: 'BEYONDTRUST_TENANT'
-          value: dataCollection.beyondTrustTenant
+          name: 'BEYONDTRUST_URL'
+          value: dataCollection.beyondTrustApplianceUrl
         }
         {
             name: 'KEYVAULT_NAME'


### PR DESCRIPTION
Update BeyondTrust config to use URL instead of tenant name

Updated Program.cs to use BEYONDTRUST_URL for BaseAddress.
Modified BeyondTrustCredentialClient.cs to accept beyondTrustUrl.
Revised main.bicep and functionapp.bicep to use beyondTrustApplianceUrl.
Replaced environment variable BEYONDTRUST_TENANT with BEYONDTRUST_URL.

#### PR Classification
Configuration update for BeyondTrust integration.

#### PR Summary
Updated environment variable handling and configuration for BeyondTrust integration.
- **Program.cs**: Replaced `BEYONDTRUST_TENANT` with `BEYONDTRUST_URL` and updated `GetAccessToken` method.
- **BeyondTrustCredentialClient.cs**: Changed `GetAccessToken` method parameter to use `beyondTrustUrl`.
- **main.bicep**: Replaced `beyondTrustTenant` with `beyondTrustApplianceUrl` in parameters and modules.
- **functionapp.bicep**: Updated `dataCollectionConfig` and environment variable to use `beyondTrustApplianceUrl`.
